### PR TITLE
Fix syntax error FIELD=$eq.VALUE to FIELD:$eq.VALUE

### DIFF
--- a/content/query-statements/_index.en.md
+++ b/content/query-statements/_index.en.md
@@ -8,7 +8,7 @@ menu: main
 ### Filter (WHERE)
 
 ```
-GET /DATABASE/SCHEMA/TABLE?FIELD=$eq.VALUE
+GET /DATABASE/SCHEMA/TABLE?FIELD:$eq.VALUE
 ```
 
 Query Operators:


### PR DESCRIPTION
Found that using FIELD=$eq.VALUE is invalid