### PR TITLE
Add port 6000 blockage infomation to configurations toml

### DIFF
--- a/content/configurations/_index.en.md
+++ b/content/configurations/_index.en.md
@@ -30,7 +30,8 @@ Optionally the pREST can be configured by TOML file.
 migrations = "./migrations"
 
 [http]
-port = 6000
+port = 6000 
+# Port 6000 is blocked on windows. You must change to 8080 or any unblocked port
 
 [jwt]
 key = "secret"


### PR DESCRIPTION
This PR adds information about port `6000` blocked on windows. This PR is a reference to issue [301 on the prest repo](https://github.com/prest/prest/issues/301) and this pr when merged will prevent issues like [Issue 297](https://github.com/prest/prest/issues/297)