### PR TITLE
Update incorrect table name attribute

### DIFF
--- a/content/permissions/_index.en.md
+++ b/content/permissions/_index.en.md
@@ -47,7 +47,7 @@ restrict = true  # can access only the tables listed below
 
 |attribute|description|
 |---|---|
-|table|Table name|
+|name|Table name|
 |permissions|Table permissions. Options: `read`, `write` and `delete`|
 |fields|Fields permitted for operations|
 


### PR DESCRIPTION
The attribute of table name should be `name` instead of `table` based on what I read from the documentation and the examples.